### PR TITLE
Custom Log Stream macro added for categorizing the logs of background tasks.

### DIFF
--- a/.idea/aws.xml
+++ b/.idea/aws.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="accountSettings">
+    <option name="activeRegion" value="us-east-1" />
+    <option name="recentlyUsedRegions">
+      <list>
+        <option value="us-east-1" />
+      </list>
+    </option>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/readme.md
+++ b/readme.md
@@ -18,3 +18,8 @@ log!(Level::Info, "This is an info message");
 log!(Level::Error, "This is an error message");
 log!(Level::Debug, "Debugging information");
 ```
+To log in a custom stream (other than info, error and debug) you can use log_custom macro
+```
+log_custom!(Level::Info,"Custom Stream Name", "This is the message and variable {}",variable);
+
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,9 +31,9 @@ macro_rules! log_custom {
 
         if log_to_cloudwatch {
             let message_str = format!($($arg)+);
-            let log_stream_str = $log_stream.to_string(); // Convert the log stream to a string if necessary
-            tokio::spawn(async move {
-                let _ = $crate::logs::log($level, &message_str, &log_stream_str, file!(), line!()).await;
+            let log_stream = $crate::logs::LogStream::from_string($log_stream);
+             tokio::spawn(async move {
+                let _ = $crate::logs::log($level, &message_str, log_stream, file!(), line!()).await;
             });
         } else {
             match $level {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,27 +23,25 @@ macro_rules! log {
         }
     }};
 }
-
-
-#[macro_export]
 macro_rules! log_custom {
-    ($level:expr, $log_stream:expr, $($arg:tt)+) => {{
+    ($level:expr, $($arg:tt)+) => {{
         let log_to_cloudwatch = std::env::var("LOG_TO_CLOUDWATCH").unwrap_or_else(|_| "false".to_string()) == "true";
 
         if log_to_cloudwatch {
             let message_str = format!($($arg)+);
-            let log_stream_clone = $log_stream.clone(); // Clone if necessary
+            let log_stream = $crate::logs::LogStream::from_level(&$level);
             tokio::spawn(async move {
-                let _ = $crate::logs::log($level, &message_str, log_stream_clone, file!(), line!()).await;
+                let _ = $crate::logs::log($level, &message_str, log_stream, file!(), line!()).await;
             });
         } else {
             match $level {
                 log::Level::Error => println!("ERROR: {}", format!($($arg)+)),
-                log::Level::Warn  => println!("WARN: {}", format!($($arg)+)),
-                log::Level::Info  => println!("INFO: {}", format!($($arg)+)),
+                log::Level::Warn => println!("WARN: {}", format!($($arg)+)),
+                log::Level::Info => println!("INFO: {}", format!($($arg)+)),
                 log::Level::Debug => println!("DEBUG: {}", format!($($arg)+)),
                 log::Level::Trace => println!("TRACE: {}", format!($($arg)+)),
             }
         }
     }};
 }
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,9 +31,9 @@ macro_rules! log_custom {
 
         if log_to_cloudwatch {
             let message_str = format!($($arg)+);
-            let log_stream_clone = $log_stream.clone(); // Clone if necessary
+            let log_stream_str = $log_stream.to_string(); // Convert the log stream to a string if necessary
             tokio::spawn(async move {
-                let _ = $crate::logs::log($level, &message_str, log_stream_clone, file!(), line!()).await;
+                let _ = $crate::logs::log($level, &message_str, &log_stream_str, file!(), line!()).await;
             });
         } else {
             match $level {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,8 @@ macro_rules! log {
         }
     }};
 }
+
+
 #[macro_export]
 macro_rules! log_custom {
     ($level:expr, $log_stream:expr, $($arg:tt)+) => {{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,3 +23,24 @@ macro_rules! log {
         }
     }};
 }
+macro_rules! log_custom {
+    ($level:expr, $log_stream:expr, $($arg:tt)+) => {{
+        let log_to_cloudwatch = std::env::var("LOG_TO_CLOUDWATCH").unwrap_or_else(|_| "false".to_string()) == "true";
+
+        if log_to_cloudwatch {
+            let message_str = format!($($arg)+);
+            let log_stream_clone = $log_stream.clone(); // Clone if necessary
+            tokio::spawn(async move {
+                let _ = $crate::logs::log($level, &message_str, log_stream_clone, file!(), line!()).await;
+            });
+        } else {
+            match $level {
+                log::Level::Error => println!("ERROR: {}", format!($($arg)+)),
+                log::Level::Warn  => println!("WARN: {}", format!($($arg)+)),
+                log::Level::Info  => println!("INFO: {}", format!($($arg)+)),
+                log::Level::Debug => println!("DEBUG: {}", format!($($arg)+)),
+                log::Level::Trace => println!("TRACE: {}", format!($($arg)+)),
+            }
+        }
+    }};
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,12 +36,13 @@ macro_rules! log_custom {
                 let _ = $crate::logs::log($level, &message_str, stream, file!(), line!()).await;
             });
         } else {
+
             match $level {
-                log::Level::Error => println!("ERROR: {}", format!($($arg)+)),
-                log::Level::Warn  => println!("WARN: {}", format!($($arg)+)),
-                log::Level::Info  => println!("INFO: {}", format!($($arg)+)),
-                log::Level::Debug => println!("DEBUG: {}", format!($($arg)+)),
-                log::Level::Trace => println!("TRACE: {}", format!($($arg)+)),
+                log::Level::Error => println!("{} ::ERROR: {}",$log_stream, format!($($arg)+)),
+                log::Level::Warn  => println!("{} ::WARN: {}",$log_stream, format!($($arg)+)),
+                log::Level::Info  => println!("{} ::INFO: {}",$log_stream, format!($($arg)+)),
+                log::Level::Debug => println!("{} ::DEBUG: {}",$log_stream, format!($($arg)+)),
+                log::Level::Trace => println!("{} ::TRACE: {}",$log_stream, format!($($arg)+)),
             }
         }
     }};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,9 +31,9 @@ macro_rules! log_custom {
 
         if log_to_cloudwatch {
             let message_str = format!($($arg)+);
-            let log_stream = $crate::logs::LogStream::from_string($log_stream);
-             tokio::spawn(async move {
-                let _ = $crate::logs::log($level, &message_str, log_stream, file!(), line!()).await;
+            let stream = $crate::logs::LogStream::Custom($log_stream.to_string());
+            tokio::spawn(async move {
+                let _ = $crate::logs::log($level, &message_str, stream, file!(), line!()).await;
             });
         } else {
             match $level {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,22 +23,23 @@ macro_rules! log {
         }
     }};
 }
+
 #[macro_export]
 macro_rules! log_custom {
-    ($level:expr, $($arg:tt)+) => {{
+    ($level:expr, $log_stream:expr, $($arg:tt)+) => {{
         let log_to_cloudwatch = std::env::var("LOG_TO_CLOUDWATCH").unwrap_or_else(|_| "false".to_string()) == "true";
 
         if log_to_cloudwatch {
             let message_str = format!($($arg)+);
-            let log_stream = $crate::logs::LogStream::from_level(&$level);
+            let log_stream_clone = $log_stream.clone(); // Clone if necessary
             tokio::spawn(async move {
-                let _ = $crate::logs::log($level, &message_str, log_stream, file!(), line!()).await;
+                let _ = $crate::logs::log($level, &message_str, log_stream_clone, file!(), line!()).await;
             });
         } else {
             match $level {
                 log::Level::Error => println!("ERROR: {}", format!($($arg)+)),
-                log::Level::Warn => println!("WARN: {}", format!($($arg)+)),
-                log::Level::Info => println!("INFO: {}", format!($($arg)+)),
+                log::Level::Warn  => println!("WARN: {}", format!($($arg)+)),
+                log::Level::Info  => println!("INFO: {}", format!($($arg)+)),
                 log::Level::Debug => println!("DEBUG: {}", format!($($arg)+)),
                 log::Level::Trace => println!("TRACE: {}", format!($($arg)+)),
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ macro_rules! log {
         }
     }};
 }
+#[macro_export]
 macro_rules! log_custom {
     ($level:expr, $($arg:tt)+) => {{
         let log_to_cloudwatch = std::env::var("LOG_TO_CLOUDWATCH").unwrap_or_else(|_| "false".to_string()) == "true";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ macro_rules! log {
         }
     }};
 }
+#[macro_export]
 macro_rules! log_custom {
     ($level:expr, $log_stream:expr, $($arg:tt)+) => {{
         let log_to_cloudwatch = std::env::var("LOG_TO_CLOUDWATCH").unwrap_or_else(|_| "false".to_string()) == "true";

--- a/src/logs.rs
+++ b/src/logs.rs
@@ -38,6 +38,17 @@ impl LogStream {
         }
     }
 
+    pub fn from_string(stream_name:String)->Self{
+        match stream_name.as_str() {
+            "Server_Responses" => LogStream::ServerResponses,
+            "Client_Responses" => LogStream::ClientResponses,
+            "Redirection_Responses" => LogStream::RedirectionResponses,
+            "Successful_Responses" => LogStream::SuccessfulResponses,
+            "Informational_Responses" => LogStream::InformationalResponses,
+            "Unknown_Or_Unassigned" => LogStream::UnknownOrUnassigned,
+            _ => LogStream::Custom(stream_name),
+        }
+    }
     fn with_date(&self) -> String {
         let current_date = Utc::now().format("%Y-%m-%d").to_string();
         format!("{}-{}", current_date, self.as_str())

--- a/src/logs.rs
+++ b/src/logs.rs
@@ -112,7 +112,13 @@ async fn handle_logging_operation(client: CloudWatchLogsClient, log_group_name: 
     Ok(())
 }
 
-pub async fn log(level: Level, message: &str, log_stream: LogStream, file: &str, line: u32) -> Result<(), Error> {
+pub async fn log(
+    level: Level,
+    message: &str,
+    log_stream: LogStream,
+    file: &str,
+    line: u32
+) -> Result<(), Error> {
     let log_group_name = match env::var("AWS_LOG_GROUP") {
         Ok(name) => name,
         Err(_) => return Err(Error::EnvVarMissing("AWS_LOG_GROUP".to_string())),
@@ -135,21 +141,56 @@ pub async fn log(level: Level, message: &str, log_stream: LogStream, file: &str,
     let log_stream_name_clone = log_stream_name.clone();
 
     tokio::spawn(async move {
-        if ensure_log_stream_exists(&client_clone, &log_group_name_clone, &log_stream_name_clone).await.is_ok() {
+        if ensure_log_stream_exists(&client_clone, &log_group_name_clone, &log_stream_name_clone)
+            .await
+            .is_ok()
+        {
             let _ = handle_logging_operation(client_clone, log_group_name_clone, log_stream_name_clone, message_str).await;
         }
     });
 
+    // Custom stream check
     match level {
-        Level::Error => error!("{}", message),
-        Level::Warn => warn!("{}", message),
-        Level::Info => info!("{}", message),
-        Level::Debug => debug!("{}", message),
-        Level::Trace => trace!("{}", message),
+        Level::Error => {
+            if let LogStream::Custom(ref stream_name) = log_stream {
+                error!("Stream [{}] - {}", stream_name, message);
+            } else {
+                error!("{}", message);
+            }
+        },
+        Level::Warn => {
+            if let LogStream::Custom(ref stream_name) = log_stream {
+                warn!("Stream [{}] - {}", stream_name, message);
+            } else {
+                warn!("{}", message);
+            }
+        },
+        Level::Info => {
+            if let LogStream::Custom(ref stream_name) = log_stream {
+                info!("Stream [{}] - {}", stream_name, message);
+            } else {
+                info!("{}", message);
+            }
+        },
+        Level::Debug => {
+            if let LogStream::Custom(ref stream_name) = log_stream {
+                debug!("Stream [{}] - {}", stream_name, message);
+            } else {
+                debug!("{}", message);
+            }
+        },
+        Level::Trace => {
+            if let LogStream::Custom(ref stream_name) = log_stream {
+                trace!("Stream [{}] - {}", stream_name, message);
+            } else {
+                trace!("{}", message);
+            }
+        },
     }
 
     Ok(())
 }
+
 
 async fn ensure_log_group_exists(client: &CloudWatchLogsClient, log_group_name: &str) -> Result<(), Box<dyn error::Error>> {
     let resp = client

--- a/src/logs.rs
+++ b/src/logs.rs
@@ -22,10 +22,11 @@ pub enum LogStream {
     SuccessfulResponses,
     InformationalResponses,
     UnknownOrUnassigned,
+    Custom(String),
 }
 
 impl LogStream {
-    fn as_str(&self) -> &'static str {
+    fn as_str(&self) -> &str {
         match *self {
             LogStream::ServerResponses => "Server_Responses",
             LogStream::ClientResponses => "Client_Responses",
@@ -33,6 +34,7 @@ impl LogStream {
             LogStream::SuccessfulResponses => "Successful_Responses",
             LogStream::InformationalResponses => "Informational_Responses",
             LogStream::UnknownOrUnassigned => "Unknown_Or_Unassigned",
+            LogStream::Custom(ref s) => s,
         }
     }
 


### PR DESCRIPTION
To log in a custom stream (other than info, error and debug) you can use log_custom macro

`
log_custom!(Level::Info,"Custom Stream Name", "This is the message and variable {}",variable);
`